### PR TITLE
support network shutdown

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -15,7 +15,7 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-func (nt *Network) setUDPForwarder() {
+func (nt *Network) setUDPForwarder(ctx context.Context) {
 	udpForwarder := udp.NewForwarder(nt.stack, func(fr *udp.ForwarderRequest) {
 		id := fr.ID()
 
@@ -63,7 +63,7 @@ func (nt *Network) setUDPForwarder() {
 
 		client := gonet.NewUDPConn(nt.stack, &wq, ep)
 
-		ctx := slog.NewContext(context.Background(), nt.logger)
+		ctx := slog.NewContext(ctx, nt.logger)
 		ctx, cancel := context.WithCancel(ctx)
 
 		idleTimeout := time.Minute


### PR DESCRIPTION
This change does two things:

- `LinkDevice.Close()` now also closes the tcp forwarder listener.
- Adds `Shutdown()` to `Network`:
  - This uses `stack.Destroy()` which should destroy all endpoints. This should also terminate tcp forwarder listeners, as the connection now given in `RegisterConn` is wrapped with a closer that closes in the same way as `LinkDevice.Close()`.
  - Cancels a parent context. This context is now passed to a few of the subsystems (`serveDNS4Server`, `setUDPForwarder`, `setTCPForwarder`)

I wanted to be able to create multiple network stacks within the same application but it wasn't possible to cleanup a stack after it was used.